### PR TITLE
Allow on `heroku-24` stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 ##  About <a name = "about"></a>
 
 This buildpack downloads and extracts the
-[wkhtmltopdf](https://wkhtmltopdf.org/) binaries and works on `heroku-18`, `heroku-20` and `heroku-22` stacks.
+[wkhtmltopdf](https://wkhtmltopdf.org/) binaries and works on `heroku-18`, `heroku-20`, `heroku-22` and `heroku-24` stacks.
 
 - This buildpack downloads wkhtmltopdf v0.12.6.1-2 for `heroku-22`, v0.12.6-1 for `heroku-20` stack and v0.12.5 for `heroku-18` stack.
 - This buildpack can bypass stack detection if the url to the wkhtmltopdf binary is provided through Aptfile.
@@ -39,10 +39,13 @@ This buildpack downloads and extracts the
     - Added support for `Heroku-22`
     - Added support for bypassing stack detection.
 
+- v4
+    - Added support for `Heroku-24`
+
 ## Features <a name = "feature"></a>
 - Downloads wkhtmltopdf binaries from [wkhtmltopdf.org](http://wkhtmltopdf.org)
 - It doesnot add new environment variables or shell scripts.
-- Tested on `heroku-22`, `heroku-20` and `heroku-18`stack images.
+- Tested on `heroku-24`, `heroku-22`, `heroku-20` and `heroku-18`stack images.
 - It allows you to specify a custom or the latest version of wkhtmltopdf package for your app on Heroku. [Aptfile](#aptfile).
 
 ## Getting Started <a name = "getting_started"></a>

--- a/bin/detect
+++ b/bin/detect
@@ -3,9 +3,9 @@
 
 BUILD_DIR=$1
 
-if [ -f "$BUILD_DIR/Aptfile" ] || [ "$STACK" = "heroku-18" ] || [ "$STACK" = "heroku-20" ] || [ "$STACK" = "heroku-22" ]; then
+if [ -f "$BUILD_DIR/Aptfile" ] || [ "$STACK" = "heroku-18" ] || [ "$STACK" = "heroku-20" ] || [ "$STACK" = "heroku-22" ] || [ "$STACK" = "heroku-24" ]; then
 	echo "wkhtmltopdf"
 else
-	echo "ERROR: wkhtmltopdf was tested only to work on heroku-18, heroku-20 and heroku-22 stacks only."
+	echo "ERROR: wkhtmltopdf was tested only to work on heroku-18, heroku-20, heroku-22 and heroku-24 stacks only."
 	exit 1
 fi


### PR DESCRIPTION
- Allows buildpack to be used on `heroku-24` stack
- Tested and confirmed that wkhtmltopdf `0.12.6.1-2` still works on this stack, so I didn't update that. We can update it in a future PR if and when required.